### PR TITLE
Add `ephemeral` property to reply payload

### DIFF
--- a/commands/roleAdd/roleAdd.js
+++ b/commands/roleAdd/roleAdd.js
@@ -32,5 +32,5 @@ export async function execute(interaction) {
     message = Err.getReply(err);
   }
   debug("message:", message);
-  await interaction.reply(message);
+  await interaction.reply({ content: message, ephemeral: true });
 }

--- a/commands/roleRemove/roleRemove.js
+++ b/commands/roleRemove/roleRemove.js
@@ -32,5 +32,5 @@ export async function execute(interaction) {
     message = Err.getReply(err);
   }
   debug("message:", message);
-  await interaction.reply(message);
+  await interaction.reply({ content: message, ephemeral: true });
 }


### PR DESCRIPTION
## Description
Setting this to true will mean only the user who sent the slash command will see the reply.

Closes https://github.com/jasonflorentino/discord-bot-bs/issues/1

## Testing
Sending a slash command will result in a reply only you can see